### PR TITLE
閉じたときの目次バーが大きいのを修正

### DIFF
--- a/text-concat.user.js
+++ b/text-concat.user.js
@@ -92,6 +92,9 @@
     width: 400px;
     z-index: 999;
 }
+.indexAll.__close {
+    width: auto;
+}
 
 .indexAll>*>* {
     display: none;


### PR DESCRIPTION
開いたときは良かったんですが、キャプチャ撮るときに邪魔になりますね。
閉じたときに小さくするように修正してみました。
お暇なときにマージしていただけると幸いです。
（バージョンは変えずに、必要な人は再インストールでいいと思います）